### PR TITLE
Add admin book management

### DIFF
--- a/library-management/src/main/java/com/library/controller/AdminBookController.java
+++ b/library-management/src/main/java/com/library/controller/AdminBookController.java
@@ -1,0 +1,68 @@
+package com.library.controller;
+
+import com.library.entity.Book;
+import com.library.service.BookService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/admin/books")
+public class AdminBookController {
+
+    @Autowired
+    private BookService bookService;
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("books", bookService.getAllBooks());
+        model.addAttribute("pageTitle", "Manage Books");
+        return "admin/books/list";
+    }
+
+    @GetMapping("/new")
+    public String createForm(Model model) {
+        model.addAttribute("book", new Book());
+        model.addAttribute("pageTitle", "Add Book");
+        return "admin/books/form";
+    }
+
+    @PostMapping
+    public String create(@Valid @ModelAttribute("book") Book book, BindingResult result, Model model) {
+        if (result.hasErrors()) {
+            model.addAttribute("pageTitle", "Add Book");
+            return "admin/books/form";
+        }
+        bookService.saveBook(book);
+        return "redirect:/admin/books";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        Book book = bookService.getBook(id);
+        model.addAttribute("book", book);
+        model.addAttribute("pageTitle", "Edit Book");
+        return "admin/books/form";
+    }
+
+    @PostMapping("/{id}")
+    public String update(@PathVariable Long id, @Valid @ModelAttribute("book") Book book,
+                         BindingResult result, Model model) {
+        if (result.hasErrors()) {
+            model.addAttribute("pageTitle", "Edit Book");
+            return "admin/books/form";
+        }
+        book.setId(id);
+        bookService.saveBook(book);
+        return "redirect:/admin/books";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id) {
+        bookService.deleteBook(id);
+        return "redirect:/admin/books";
+    }
+}

--- a/library-management/src/main/java/com/library/service/BookService.java
+++ b/library-management/src/main/java/com/library/service/BookService.java
@@ -33,4 +33,12 @@ public class BookService {
         }
         return bookRepository.search(query);
     }
+
+    public Book saveBook(Book book) {
+        return bookRepository.save(book);
+    }
+
+    public void deleteBook(Long id) {
+        bookRepository.deleteById(id);
+    }
 }

--- a/library-management/src/main/resources/templates/admin/books/form.html
+++ b/library-management/src/main/resources/templates/admin/books/form.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Book Form</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" th:href="@{/}"><i class="bi bi-book"></i> Library Management</a>
+    </div>
+</nav>
+
+<div class="container my-5">
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Book Form</h1>
+    <form th:action="${book.id} == null ? @{/admin/books} : @{'/admin/books/' + ${book.id}}" method="post" th:object="${book}">
+        <div class="mb-3">
+            <label for="title" class="form-label">Title</label>
+            <input type="text" class="form-control" id="title" th:field="*{title}" required>
+        </div>
+        <div class="mb-3">
+            <label for="author" class="form-label">Author</label>
+            <input type="text" class="form-control" id="author" th:field="*{author}" required>
+        </div>
+        <div class="mb-3">
+            <label for="description" class="form-label">Description</label>
+            <textarea class="form-control" id="description" rows="3" th:field="*{description}"></textarea>
+        </div>
+        <div class="form-check mb-3">
+            <input class="form-check-input" type="checkbox" id="available" th:field="*{available}">
+            <label class="form-check-label" for="available">Available</label>
+        </div>
+        <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Save</button>
+        <a th:href="@{/admin/books}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/admin/books/list.html
+++ b/library-management/src/main/resources/templates/admin/books/list.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Manage Books</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" th:href="@{/}"><i class="bi bi-book"></i> Library Management</a>
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav">
+            <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarNav">
+            <ul class="navbar-nav me-auto">
+                <li class="nav-item"><a class="nav-link" th:href="@{/}">Home</a></li>
+                <li class="nav-item"><a class="nav-link" th:href="@{/books}">Books</a></li>
+                <li class="nav-item" sec:authorize="hasRole('ADMIN')"><a class="nav-link active" th:href="@{/admin/books}">Admin</a></li>
+            </ul>
+            <ul class="navbar-nav">
+                <li class="nav-item dropdown" sec:authorize="isAuthenticated()">
+                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown"><i class="bi bi-person-circle"></i> <span sec:authentication="name">User</span></a>
+                    <ul class="dropdown-menu">
+                        <li><form th:action="@{/logout}" method="post"><button type="submit" class="dropdown-item">Logout</button></form></li>
+                    </ul>
+                </li>
+                <li class="nav-item" sec:authorize="!isAuthenticated()"><a class="nav-link" th:href="@{/login}">Login</a></li>
+            </ul>
+        </div>
+    </div>
+</nav>
+
+<div class="container my-5">
+    <div class="d-flex justify-content-between align-items-center mb-3">
+        <h1 class="h4">Manage Books</h1>
+        <a th:href="@{/admin/books/new}" class="btn btn-success"><i class="bi bi-plus-circle"></i> Add Book</a>
+    </div>
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Title</th>
+                <th>Author</th>
+                <th>Available</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr th:each="book : ${books}">
+                <td th:text="${book.id}"></td>
+                <td th:text="${book.title}"></td>
+                <td th:text="${book.author}"></td>
+                <td>
+                    <span th:text="${book.available} ? 'Yes' : 'No'"></span>
+                </td>
+                <td>
+                    <a th:href="@{'/admin/books/' + ${book.id} + '/edit'}" class="btn btn-sm btn-primary"><i class="bi bi-pencil"></i> Edit</a>
+                    <form th:action="@{'/admin/books/' + ${book.id} + '/delete'}" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this book?');"><i class="bi bi-trash"></i> Delete</button>
+                    </form>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/books/list.html
+++ b/library-management/src/main/resources/templates/books/list.html
@@ -38,7 +38,7 @@
                     </a>
                 </li>
                 <li class="nav-item" sec:authorize="hasRole('ADMIN')">
-                    <a class="nav-link" th:href="@{/admin}">
+                    <a class="nav-link" th:href="@{/admin/books}">
                         <i class="bi bi-gear"></i> Admin
                     </a>
                 </li>

--- a/library-management/src/main/resources/templates/dashboard.html
+++ b/library-management/src/main/resources/templates/dashboard.html
@@ -38,7 +38,7 @@
                     </a>
                 </li>
                 <li class="nav-item" sec:authorize="hasRole('ADMIN')">
-                    <a class="nav-link" th:href="@{/admin}">
+                    <a class="nav-link" th:href="@{/admin/books}">
                         <i class="bi bi-gear"></i> Admin
                     </a>
                 </li>


### PR DESCRIPTION
## Summary
- load books from the database via `BookService`
- add `AdminBookController` for CRUD on books
- include templates for listing and editing books under `/admin/books`
- update navigation links to the admin section

## Testing
- `mvn -v` *(fails: command not found)*
- `./mvnw -q -DskipTests package` *(fails: wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_685def28c818832f96a491750d2d25c5