### PR TITLE
Fix admin dashboard redirect

### DIFF
--- a/library-management/src/main/java/com/library/controller/HomeController.java
+++ b/library-management/src/main/java/com/library/controller/HomeController.java
@@ -67,10 +67,11 @@ public class HomeController {
 
     @GetMapping("/dashboard")
     public String dashboard(Model model, Authentication authentication) {
-        String username = authentication.getName();
-        User user = userService.findByUsername(username)
-                .orElseThrow(() -> new RuntimeException("User not found"));
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return "redirect:/login";
+        }
 
+        User user = (User) authentication.getPrincipal();
         model.addAttribute("user", user);
         model.addAttribute("pageTitle", "Dashboard");
 


### PR DESCRIPTION
## Summary
- avoid extra DB lookup in `/dashboard`
- cast principal from `Authentication` directly

## Testing
- `mvn -q test` *(fails: mvn not found)*
- `sh mvnw -q test` *(fails: Maven wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_685df1d1e47c832f85829c4d131dcef1