### PR TITLE
Add admin dashboard and user management

### DIFF
--- a/library-management/src/main/java/com/library/controller/AdminDashboardController.java
+++ b/library-management/src/main/java/com/library/controller/AdminDashboardController.java
@@ -1,0 +1,17 @@
+package com.library.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin")
+public class AdminDashboardController {
+
+    @GetMapping("/dashboard")
+    public String dashboard(Model model) {
+        model.addAttribute("pageTitle", "Admin Dashboard");
+        return "admin/dashboard";
+    }
+}

--- a/library-management/src/main/java/com/library/controller/AdminUserController.java
+++ b/library-management/src/main/java/com/library/controller/AdminUserController.java
@@ -1,0 +1,50 @@
+package com.library.controller;
+
+import com.library.entity.User;
+import com.library.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/admin/users")
+public class AdminUserController {
+
+    @Autowired
+    private UserService userService;
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("users", userService.findAllUsers());
+        model.addAttribute("pageTitle", "Manage Users");
+        return "admin/users/list";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        User user = userService.findById(id);
+        model.addAttribute("user", user);
+        model.addAttribute("pageTitle", "Edit User");
+        return "admin/users/form";
+    }
+
+    @PostMapping("/{id}")
+    public String update(@PathVariable Long id, @Valid @ModelAttribute("user") User user, BindingResult result, Model model) {
+        if (result.hasErrors()) {
+            model.addAttribute("pageTitle", "Edit User");
+            return "admin/users/form";
+        }
+        user.setId(id);
+        userService.updateUser(id, user);
+        return "redirect:/admin/users";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id) {
+        userService.deleteUser(id);
+        return "redirect:/admin/users";
+    }
+}

--- a/library-management/src/main/java/com/library/service/UserService.java
+++ b/library-management/src/main/java/com/library/service/UserService.java
@@ -99,4 +99,8 @@ public class UserService {
     public boolean isEmailAvailable(String email) {
         return !userRepository.existsByEmail(email);
     }
+
+    public void deleteUser(Long id) {
+        userRepository.deleteById(id);
+    }
 }

--- a/library-management/src/main/resources/schema.sql
+++ b/library-management/src/main/resources/schema.sql
@@ -27,7 +27,3 @@ CREATE TABLE IF NOT EXISTS books (
     available BOOLEAN NOT NULL DEFAULT TRUE
 );
 
-INSERT INTO books (title, author, description, available) VALUES
-    ('The Great Gatsby', 'F. Scott Fitzgerald', 'A classic novel set in the Jazz Age.', true),
-    ('1984', 'George Orwell', 'Dystopian novel about totalitarianism.', true),
-    ('Dune', 'Frank Herbert', 'Science fiction epic on Arrakis.', false);

--- a/library-management/src/main/resources/templates/admin/dashboard.html
+++ b/library-management/src/main/resources/templates/admin/dashboard.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Manage Books</title>
+    <title th:text="${pageTitle}">Admin Dashboard</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
     <link th:href="@{/css/style.css}" rel="stylesheet">
@@ -23,7 +23,9 @@
             </ul>
             <ul class="navbar-nav">
                 <li class="nav-item dropdown" sec:authorize="isAuthenticated()">
-                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown"><i class="bi bi-person-circle"></i> <span sec:authentication="name">User</span></a>
+                    <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
+                        <i class="bi bi-person-circle"></i> <span sec:authentication="name">User</span>
+                    </a>
                     <ul class="dropdown-menu">
                         <li><form th:action="@{/logout}" method="post"><button type="submit" class="dropdown-item">Logout</button></form></li>
                     </ul>
@@ -35,37 +37,15 @@
 </nav>
 
 <div class="container my-5">
-    <div class="d-flex justify-content-between align-items-center mb-3">
-        <h1 class="h4">Manage Books</h1>
-        <a th:href="@{/admin/books/new}" class="btn btn-success"><i class="bi bi-plus-circle"></i> Add Book</a>
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Admin Dashboard</h1>
+    <div class="list-group">
+        <a th:href="@{/admin/books}" class="list-group-item list-group-item-action">
+            <i class="bi bi-book"></i> Manage Books
+        </a>
+        <a th:href="@{/admin/users}" class="list-group-item list-group-item-action">
+            <i class="bi bi-people"></i> Manage Users
+        </a>
     </div>
-    <table class="table table-striped">
-        <thead>
-            <tr>
-                <th>ID</th>
-                <th>Title</th>
-                <th>Author</th>
-                <th>Available</th>
-                <th>Actions</th>
-            </tr>
-        </thead>
-        <tbody>
-            <tr th:each="book : ${books}">
-                <td th:text="${book.id}"></td>
-                <td th:text="${book.title}"></td>
-                <td th:text="${book.author}"></td>
-                <td>
-                    <span th:text="${book.available} ? 'Yes' : 'No'"></span>
-                </td>
-                <td>
-                    <a th:href="@{'/admin/books/' + ${book.id} + '/edit'}" class="btn btn-sm btn-primary"><i class="bi bi-pencil"></i> Edit</a>
-                    <form th:action="@{'/admin/books/' + ${book.id} + '/delete'}" method="post" class="d-inline">
-                        <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this book?');"><i class="bi bi-trash"></i> Delete</button>
-                    </form>
-                </td>
-            </tr>
-        </tbody>
-    </table>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/library-management/src/main/resources/templates/admin/users/form.html
+++ b/library-management/src/main/resources/templates/admin/users/form.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Edit User</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" th:href="@{/}"><i class="bi bi-book"></i> Library Management</a>
+    </div>
+</nav>
+
+<div class="container my-5">
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Edit User</h1>
+    <form th:action="@{'/admin/users/' + ${user.id}}" method="post" th:object="${user}">
+        <div class="mb-3">
+            <label for="firstName" class="form-label">First Name</label>
+            <input type="text" class="form-control" id="firstName" th:field="*{firstName}" required>
+        </div>
+        <div class="mb-3">
+            <label for="lastName" class="form-label">Last Name</label>
+            <input type="text" class="form-control" id="lastName" th:field="*{lastName}" required>
+        </div>
+        <div class="mb-3">
+            <label for="email" class="form-label">Email</label>
+            <input type="email" class="form-control" id="email" th:field="*{email}" required>
+        </div>
+        <button type="submit" class="btn btn-primary"><i class="bi bi-save"></i> Save</button>
+        <a th:href="@{/admin/users}" class="btn btn-secondary">Cancel</a>
+    </form>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/admin/users/list.html
+++ b/library-management/src/main/resources/templates/admin/users/list.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Manage Users</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-primary">
+    <div class="container">
+        <a class="navbar-brand" th:href="@{/}"><i class="bi bi-book"></i> Library Management</a>
+    </div>
+</nav>
+
+<div class="container my-5">
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Manage Users</h1>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>Username</th>
+            <th>Email</th>
+            <th>Role</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="u : ${users}">
+            <td th:text="${u.id}"></td>
+            <td th:text="${u.username}"></td>
+            <td th:text="${u.email}"></td>
+            <td th:text="${u.role}"></td>
+            <td>
+                <a th:href="@{'/admin/users/' + ${u.id} + '/edit'}" class="btn btn-sm btn-primary"><i class="bi bi-pencil"></i> Edit</a>
+                <form th:action="@{'/admin/users/' + ${u.id} + '/delete'}" method="post" class="d-inline">
+                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete this user?');"><i class="bi bi-trash"></i> Delete</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/books/list.html
+++ b/library-management/src/main/resources/templates/books/list.html
@@ -38,7 +38,7 @@
                     </a>
                 </li>
                 <li class="nav-item" sec:authorize="hasRole('ADMIN')">
-                    <a class="nav-link" th:href="@{/admin/books}">
+                    <a class="nav-link" th:href="@{/admin/dashboard}">
                         <i class="bi bi-gear"></i> Admin
                     </a>
                 </li>

--- a/library-management/src/main/resources/templates/dashboard.html
+++ b/library-management/src/main/resources/templates/dashboard.html
@@ -38,7 +38,7 @@
                     </a>
                 </li>
                 <li class="nav-item" sec:authorize="hasRole('ADMIN')">
-                    <a class="nav-link" th:href="@{/admin/books}">
+                    <a class="nav-link" th:href="@{/admin/dashboard}">
                         <i class="bi bi-gear"></i> Admin
                     </a>
                 </li>


### PR DESCRIPTION
## Summary
- create `/admin/dashboard` controller and page
- allow editing and deleting users in admin area
- remove sample books from schema
- update navigation links to go to the admin dashboard

## Testing
- `mvn test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685df4e08ee0832fa1f430e58eeedf6c