### PR TITLE
Update db config and improve dashboards

### DIFF
--- a/library-management/src/main/java/com/library/controller/AdminDashboardController.java
+++ b/library-management/src/main/java/com/library/controller/AdminDashboardController.java
@@ -11,7 +11,7 @@ public class AdminDashboardController {
 
     @GetMapping("/dashboard")
     public String dashboard(Model model) {
-        model.addAttribute("pageTitle", "Admin Dashboard");
+        model.addAttribute("pageTitle", "Admin Panel");
         return "admin/dashboard";
     }
 }

--- a/library-management/src/main/java/com/library/controller/HomeController.java
+++ b/library-management/src/main/java/com/library/controller/HomeController.java
@@ -73,6 +73,7 @@ public class HomeController {
 
         User user = (User) authentication.getPrincipal();
         model.addAttribute("user", user);
+        model.addAttribute("books", bookService.getAllBooks());
         model.addAttribute("pageTitle", "Dashboard");
 
         if (user.isAdmin()) {

--- a/library-management/src/main/resources/application.yml
+++ b/library-management/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 ﻿spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/librarydb
+    url: jdbc:postgresql://localhost:5432/librarydb9
     username: postgres
     password: Lolibol1
     hikari:

--- a/library-management/src/main/resources/templates/admin/dashboard.html
+++ b/library-management/src/main/resources/templates/admin/dashboard.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title th:text="${pageTitle}">Admin Dashboard</title>
+    <title th:text="${pageTitle}">Admin Panel</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
     <link th:href="@{/css/style.css}" rel="stylesheet">
@@ -37,7 +37,7 @@
 </nav>
 
 <div class="container my-5">
-    <h1 class="h4 mb-4" th:text="${pageTitle}">Admin Dashboard</h1>
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Admin Panel</h1>
     <div class="list-group">
         <a th:href="@{/admin/books}" class="list-group-item list-group-item-action">
             <i class="bi bi-book"></i> Manage Books

--- a/library-management/src/main/resources/templates/dashboard.html
+++ b/library-management/src/main/resources/templates/dashboard.html
@@ -94,6 +94,37 @@
         </div>
     </div>
 
+    <!-- Account Info -->
+    <div class="row mb-4">
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-person"></i> Account Information</h5>
+                </div>
+                <div class="card-body">
+                    <p><strong>Username:</strong> <span th:text="${user.username}">user</span></p>
+                    <p><strong>Email:</strong> <span th:text="${user.email}">email</span></p>
+                    <p><strong>Role:</strong> <span th:text="${user.role}">role</span></p>
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-6">
+            <div class="card">
+                <div class="card-header">
+                    <h5 class="mb-0"><i class="bi bi-book"></i> Available Books</h5>
+                </div>
+                <div class="card-body">
+                    <ul class="list-group list-group-flush" th:if="${books}">
+                        <li class="list-group-item" th:each="b : ${books}">
+                            <a th:href="@{'/books/' + ${b.id} + '/details'}" th:text="${b.title} + ' by ' + ${b.author}">Book</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
+    </div>
+
     <!-- Quick Stats -->
     <div class="row mb-5 dashboard-stats">
         <div class="col-md-3 mb-3">


### PR DESCRIPTION
## Summary
- update database connection string to use `librarydb9`
- rename admin page to **Admin Panel**
- show account details and available books on the user dashboard

## Testing
- `mvn -q test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685df741c700832f8855e9669cf7239c