### PR TITLE
Fix admin dashboard routing

### DIFF
--- a/library-management/src/main/java/com/library/controller/HomeController.java
+++ b/library-management/src/main/java/com/library/controller/HomeController.java
@@ -76,11 +76,7 @@ public class HomeController {
         model.addAttribute("books", bookService.getAllBooks());
         model.addAttribute("pageTitle", "Dashboard");
 
-        if (user.isAdmin()) {
-            return "redirect:/admin/dashboard";
-        } else {
-            return "dashboard";
-        }
+        return "dashboard";
     }
 
     @GetMapping("/access-denied")


### PR DESCRIPTION
## Summary
- allow admins to view personal dashboard page when going to `/dashboard`

## Testing
- `sh mvnw -q test` *(fails: `maven-wrapper.jar: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_685dfa50601c832fbcb6ae26807cfed9