### PR TITLE
Connect dashboard stats to database

### DIFF
--- a/library-management/src/main/java/com/library/controller/HomeController.java
+++ b/library-management/src/main/java/com/library/controller/HomeController.java
@@ -2,8 +2,12 @@ package com.library.controller;
 
 import com.library.entity.User;
 import com.library.entity.Book;
-import com.library.service.UserService;
 import com.library.service.BookService;
+import com.library.service.ReservationService;
+import com.library.service.RentalService;
+import com.library.service.ReviewService;
+import com.library.service.UserService;
+import com.library.service.ViewedBookService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -20,6 +24,18 @@ public class HomeController {
 
     @Autowired
     private BookService bookService;
+
+    @Autowired
+    private RentalService rentalService;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
+    private ViewedBookService viewedBookService;
 
     @GetMapping("/")
     public String home() {
@@ -50,6 +66,7 @@ public class HomeController {
             User user = userService.findByUsername(username).orElse(null);
             if (user != null) {
                 model.addAttribute("currentUser", user);
+                viewedBookService.recordView(user, book);
             }
         }
 
@@ -75,6 +92,13 @@ public class HomeController {
         model.addAttribute("user", user);
         model.addAttribute("books", bookService.getAllBooks());
         model.addAttribute("pageTitle", "Dashboard");
+
+        model.addAttribute("activeRentalsCount", rentalService.countActiveRentals(user));
+        model.addAttribute("reservationsCount", reservationService.countByUser(user));
+        model.addAttribute("reviewsCount", reviewService.countByUser(user));
+        model.addAttribute("overdueCount", rentalService.countOverdueRentals(user));
+        model.addAttribute("currentRentals", rentalService.getCurrentRentals(user));
+        model.addAttribute("recentBooks", viewedBookService.getRecentViews(user));
 
         return "dashboard";
     }

--- a/library-management/src/main/java/com/library/entity/Rental.java
+++ b/library-management/src/main/java/com/library/entity/Rental.java
@@ -1,0 +1,58 @@
+package com.library.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "rentals")
+public class Rental {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Column(name = "rented_date", nullable = false)
+    private LocalDate rentedDate;
+
+    @Column(name = "due_date", nullable = false)
+    private LocalDate dueDate;
+
+    @Column(name = "returned_date")
+    private LocalDate returnedDate;
+
+    public Rental() {}
+
+    public Rental(User user, Book book, LocalDate rentedDate, LocalDate dueDate) {
+        this.user = user;
+        this.book = book;
+        this.rentedDate = rentedDate;
+        this.dueDate = dueDate;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Book getBook() { return book; }
+    public void setBook(Book book) { this.book = book; }
+
+    public LocalDate getRentedDate() { return rentedDate; }
+    public void setRentedDate(LocalDate rentedDate) { this.rentedDate = rentedDate; }
+
+    public LocalDate getDueDate() { return dueDate; }
+    public void setDueDate(LocalDate dueDate) { this.dueDate = dueDate; }
+
+    public LocalDate getReturnedDate() { return returnedDate; }
+    public void setReturnedDate(LocalDate returnedDate) { this.returnedDate = returnedDate; }
+
+    public boolean isReturned() { return returnedDate != null; }
+}

--- a/library-management/src/main/java/com/library/entity/Reservation.java
+++ b/library-management/src/main/java/com/library/entity/Reservation.java
@@ -1,0 +1,42 @@
+package com.library.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "reservations")
+public class Reservation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Column(name = "reservation_date", nullable = false)
+    private LocalDate reservationDate = LocalDate.now();
+
+    public Reservation() {}
+
+    public Reservation(User user, Book book) {
+        this.user = user;
+        this.book = book;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Book getBook() { return book; }
+    public void setBook(Book book) { this.book = book; }
+
+    public LocalDate getReservationDate() { return reservationDate; }
+    public void setReservationDate(LocalDate reservationDate) { this.reservationDate = reservationDate; }
+}

--- a/library-management/src/main/java/com/library/entity/Review.java
+++ b/library-management/src/main/java/com/library/entity/Review.java
@@ -1,0 +1,56 @@
+package com.library.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reviews")
+public class Review {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Column(nullable = false)
+    private int rating;
+
+    @Column(length = 1000)
+    private String comment;
+
+    @Column(name = "created_date", nullable = false)
+    private LocalDateTime createdDate = LocalDateTime.now();
+
+    public Review() {}
+
+    public Review(User user, Book book, int rating, String comment) {
+        this.user = user;
+        this.book = book;
+        this.rating = rating;
+        this.comment = comment;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Book getBook() { return book; }
+    public void setBook(Book book) { this.book = book; }
+
+    public int getRating() { return rating; }
+    public void setRating(int rating) { this.rating = rating; }
+
+    public String getComment() { return comment; }
+    public void setComment(String comment) { this.comment = comment; }
+
+    public LocalDateTime getCreatedDate() { return createdDate; }
+    public void setCreatedDate(LocalDateTime createdDate) { this.createdDate = createdDate; }
+}

--- a/library-management/src/main/java/com/library/entity/ViewedBook.java
+++ b/library-management/src/main/java/com/library/entity/ViewedBook.java
@@ -1,0 +1,42 @@
+package com.library.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "viewed_books")
+public class ViewedBook {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "book_id")
+    private Book book;
+
+    @Column(name = "viewed_date", nullable = false)
+    private LocalDateTime viewedDate = LocalDateTime.now();
+
+    public ViewedBook() {}
+
+    public ViewedBook(User user, Book book) {
+        this.user = user;
+        this.book = book;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public Book getBook() { return book; }
+    public void setBook(Book book) { this.book = book; }
+
+    public LocalDateTime getViewedDate() { return viewedDate; }
+    public void setViewedDate(LocalDateTime viewedDate) { this.viewedDate = viewedDate; }
+}

--- a/library-management/src/main/java/com/library/repository/RentalRepository.java
+++ b/library-management/src/main/java/com/library/repository/RentalRepository.java
@@ -1,0 +1,17 @@
+package com.library.repository;
+
+import com.library.entity.Rental;
+import com.library.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface RentalRepository extends JpaRepository<Rental, Long> {
+    List<Rental> findByUserAndReturnedDateIsNull(User user);
+
+    @Query("SELECT r FROM Rental r WHERE r.user = :user AND r.returnedDate IS NULL AND r.dueDate < :now")
+    List<Rental> findOverdue(@Param("user") User user, @Param("now") LocalDate now);
+}

--- a/library-management/src/main/java/com/library/repository/ReservationRepository.java
+++ b/library-management/src/main/java/com/library/repository/ReservationRepository.java
@@ -1,0 +1,11 @@
+package com.library.repository;
+
+import com.library.entity.Reservation;
+import com.library.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+    List<Reservation> findByUser(User user);
+}

--- a/library-management/src/main/java/com/library/repository/ReviewRepository.java
+++ b/library-management/src/main/java/com/library/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.library.repository;
+
+import com.library.entity.Review;
+import com.library.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+    long countByUser(User user);
+}

--- a/library-management/src/main/java/com/library/repository/ViewedBookRepository.java
+++ b/library-management/src/main/java/com/library/repository/ViewedBookRepository.java
@@ -1,0 +1,11 @@
+package com.library.repository;
+
+import com.library.entity.ViewedBook;
+import com.library.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ViewedBookRepository extends JpaRepository<ViewedBook, Long> {
+    List<ViewedBook> findTop5ByUserOrderByViewedDateDesc(User user);
+}

--- a/library-management/src/main/java/com/library/service/RentalService.java
+++ b/library-management/src/main/java/com/library/service/RentalService.java
@@ -1,0 +1,33 @@
+package com.library.service;
+
+import com.library.entity.Rental;
+import com.library.entity.User;
+import com.library.repository.RentalRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional
+public class RentalService {
+    @Autowired
+    private RentalRepository rentalRepository;
+
+    @Transactional(readOnly = true)
+    public List<Rental> getCurrentRentals(User user) {
+        return rentalRepository.findByUserAndReturnedDateIsNull(user);
+    }
+
+    @Transactional(readOnly = true)
+    public long countActiveRentals(User user) {
+        return rentalRepository.findByUserAndReturnedDateIsNull(user).size();
+    }
+
+    @Transactional(readOnly = true)
+    public long countOverdueRentals(User user) {
+        return rentalRepository.findOverdue(user, LocalDate.now()).size();
+    }
+}

--- a/library-management/src/main/java/com/library/service/ReservationService.java
+++ b/library-management/src/main/java/com/library/service/ReservationService.java
@@ -1,0 +1,27 @@
+package com.library.service;
+
+import com.library.entity.Reservation;
+import com.library.entity.User;
+import com.library.repository.ReservationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class ReservationService {
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Transactional(readOnly = true)
+    public List<Reservation> findByUser(User user) {
+        return reservationRepository.findByUser(user);
+    }
+
+    @Transactional(readOnly = true)
+    public long countByUser(User user) {
+        return reservationRepository.findByUser(user).size();
+    }
+}

--- a/library-management/src/main/java/com/library/service/ReviewService.java
+++ b/library-management/src/main/java/com/library/service/ReviewService.java
@@ -1,0 +1,19 @@
+package com.library.service;
+
+import com.library.entity.User;
+import com.library.repository.ReviewRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ReviewService {
+    @Autowired
+    private ReviewRepository reviewRepository;
+
+    @Transactional(readOnly = true)
+    public long countByUser(User user) {
+        return reviewRepository.countByUser(user);
+    }
+}

--- a/library-management/src/main/java/com/library/service/ViewedBookService.java
+++ b/library-management/src/main/java/com/library/service/ViewedBookService.java
@@ -1,0 +1,28 @@
+package com.library.service;
+
+import com.library.entity.Book;
+import com.library.entity.User;
+import com.library.entity.ViewedBook;
+import com.library.repository.ViewedBookRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class ViewedBookService {
+    @Autowired
+    private ViewedBookRepository viewedBookRepository;
+
+    public void recordView(User user, Book book) {
+        ViewedBook vb = new ViewedBook(user, book);
+        viewedBookRepository.save(vb);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ViewedBook> getRecentViews(User user) {
+        return viewedBookRepository.findTop5ByUserOrderByViewedDateDesc(user);
+    }
+}

--- a/library-management/src/main/resources/schema.sql
+++ b/library-management/src/main/resources/schema.sql
@@ -27,3 +27,35 @@ CREATE TABLE IF NOT EXISTS books (
     available BOOLEAN NOT NULL DEFAULT TRUE
 );
 
+CREATE TABLE IF NOT EXISTS rentals (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    book_id BIGINT NOT NULL REFERENCES books(id),
+    rented_date DATE NOT NULL,
+    due_date DATE NOT NULL,
+    returned_date DATE
+);
+
+CREATE TABLE IF NOT EXISTS reservations (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    book_id BIGINT NOT NULL REFERENCES books(id),
+    reservation_date DATE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS reviews (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    book_id BIGINT NOT NULL REFERENCES books(id),
+    rating INTEGER NOT NULL,
+    comment TEXT,
+    created_date TIMESTAMP NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS viewed_books (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    book_id BIGINT NOT NULL REFERENCES books(id),
+    viewed_date TIMESTAMP NOT NULL
+);
+

--- a/library-management/src/main/resources/templates/dashboard.html
+++ b/library-management/src/main/resources/templates/dashboard.html
@@ -69,7 +69,7 @@
                 <div class="card-body">
                     <i class="bi bi-book-half feature-icon text-primary"></i>
                     <h5 class="card-title">Active Rentals</h5>
-                    <h2 class="text-primary mb-0">3</h2>
+                    <h2 class="text-primary mb-0" th:text="${activeRentalsCount}">0</h2>
                     <small class="text-muted">of 5 max</small>
                 </div>
             </div>
@@ -80,7 +80,7 @@
                 <div class="card-body">
                     <i class="bi bi-bookmark-check feature-icon text-warning"></i>
                     <h5 class="card-title">Reservations</h5>
-                    <h2 class="text-warning mb-0">1</h2>
+                    <h2 class="text-warning mb-0" th:text="${reservationsCount}">0</h2>
                     <small class="text-muted">pending</small>
                 </div>
             </div>
@@ -91,7 +91,7 @@
                 <div class="card-body">
                     <i class="bi bi-star-half feature-icon text-info"></i>
                     <h5 class="card-title">Reviews</h5>
-                    <h2 class="text-info mb-0">12</h2>
+                    <h2 class="text-info mb-0" th:text="${reviewsCount}">0</h2>
                     <small class="text-muted">written</small>
                 </div>
             </div>
@@ -102,7 +102,7 @@
                 <div class="card-body">
                     <i class="bi bi-exclamation-triangle feature-icon text-danger"></i>
                     <h5 class="card-title">Overdue</h5>
-                    <h2 class="text-danger mb-0">0</h2>
+                    <h2 class="text-danger mb-0" th:text="${overdueCount}">0</h2>
                     <small class="text-muted">books</small>
                 </div>
             </div>
@@ -136,41 +136,19 @@
             </div>
         </div>
 
-        <!-- Recent Activity -->
+        <!-- Recently Viewed Books -->
         <div class="col-md-6 mb-4">
             <div class="card h-100">
                 <div class="card-header">
-                    <h5 class="mb-0"><i class="bi bi-clock-history"></i> Recent Activity</h5>
+                    <h5 class="mb-0"><i class="bi bi-clock-history"></i> Ostatnio przeglądane książki</h5>
                 </div>
                 <div class="card-body">
-                    <div class="list-group list-group-flush">
-                        <div class="list-group-item d-flex justify-content-between align-items-start border-0 px-0">
+                    <div class="list-group list-group-flush" th:if="${recentBooks}">
+                        <div class="list-group-item d-flex justify-content-between align-items-start border-0 px-0" th:each="v : ${recentBooks}">
                             <div class="me-auto">
-                                <div class="fw-bold">Rented "1984"</div>
-                                <small class="text-muted">Due: December 15, 2024</small>
+                                <div class="fw-bold" th:text="${v.book.title}">Title</div>
+                                <small class="text-muted" th:text="${#dates.format(v.viewedDate, 'yyyy-MM-dd HH:mm')}">date</small>
                             </div>
-                            <span class="badge bg-primary rounded-pill">Active</span>
-                        </div>
-                        <div class="list-group-item d-flex justify-content-between align-items-start border-0 px-0">
-                            <div class="me-auto">
-                                <div class="fw-bold">Reviewed "Harry Potter"</div>
-                                <small class="text-muted">Rated 5 stars</small>
-                            </div>
-                            <span class="badge bg-warning rounded-pill">⭐⭐⭐⭐⭐</span>
-                        </div>
-                        <div class="list-group-item d-flex justify-content-between align-items-start border-0 px-0">
-                            <div class="me-auto">
-                                <div class="fw-bold">Reserved "Dune"</div>
-                                <small class="text-muted">Position #1 in queue</small>
-                            </div>
-                            <span class="badge bg-success rounded-pill">Next</span>
-                        </div>
-                        <div class="list-group-item d-flex justify-content-between align-items-start border-0 px-0">
-                            <div class="me-auto">
-                                <div class="fw-bold">Returned "The Great Gatsby"</div>
-                                <small class="text-muted">3 days ago</small>
-                            </div>
-                            <span class="badge bg-secondary rounded-pill">Returned</span>
                         </div>
                     </div>
                 </div>
@@ -198,48 +176,16 @@
                                 <th>Actions</th>
                             </tr>
                             </thead>
-                            <tbody>
-                            <tr>
+                            <tbody th:if="${currentRentals}">
+                            <tr th:each="r : ${currentRentals}">
+                                <td><strong th:text="${r.book.title}">Title</strong></td>
+                                <td th:text="${r.book.author}">Author</td>
+                                <td th:text="${#dates.format(r.rentedDate, 'yyyy-MM-dd')}">date</td>
+                                <td th:text="${#dates.format(r.dueDate, 'yyyy-MM-dd')}">date</td>
                                 <td>
-                                    <strong>1984</strong>
+                                    <span th:classappend="${r.dueDate.isBefore(T(java.time.LocalDate).now())} ? 'badge bg-danger' : 'badge bg-success'" th:text="${r.dueDate.isBefore(T(java.time.LocalDate).now())} ? 'Overdue' : 'On Time'">Status</span>
                                 </td>
-                                <td>George Orwell</td>
-                                <td>Dec 1, 2024</td>
-                                <td>Dec 15, 2024</td>
-                                <td><span class="badge bg-success">On Time</span></td>
-                                <td>
-                                    <button class="btn btn-sm btn-outline-primary">
-                                        <i class="bi bi-arrow-clockwise"></i> Extend
-                                    </button>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <strong>To Kill a Mockingbird</strong>
-                                </td>
-                                <td>Harper Lee</td>
-                                <td>Nov 28, 2024</td>
-                                <td>Dec 12, 2024</td>
-                                <td><span class="badge bg-success">On Time</span></td>
-                                <td>
-                                    <button class="btn btn-sm btn-outline-primary">
-                                        <i class="bi bi-arrow-clockwise"></i> Extend
-                                    </button>
-                                </td>
-                            </tr>
-                            <tr>
-                                <td>
-                                    <strong>Harry Potter</strong>
-                                </td>
-                                <td>J.K. Rowling</td>
-                                <td>Nov 25, 2024</td>
-                                <td>Dec 9, 2024</td>
-                                <td><span class="badge bg-success">On Time</span></td>
-                                <td>
-                                    <button class="btn btn-sm btn-outline-primary">
-                                        <i class="bi bi-arrow-clockwise"></i> Extend
-                                    </button>
-                                </td>
+                                <td></td>
                             </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
## Summary
- add rental, reservation, review and viewed book entities
- create repositories and services for new entities
- update schema.sql for new tables
- record viewed books when showing book details
- show counts and lists from database on dashboard

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685dfc8ff168832fa475c478a312f07a