### PR TITLE
Add rental options and user account pages

### DIFF
--- a/library-management/src/main/java/com/library/controller/AccountController.java
+++ b/library-management/src/main/java/com/library/controller/AccountController.java
@@ -1,0 +1,53 @@
+package com.library.controller;
+
+import com.library.entity.User;
+import com.library.service.RentalService;
+import com.library.service.ReservationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class AccountController {
+
+    @Autowired
+    private RentalService rentalService;
+
+    @Autowired
+    private ReservationService reservationService;
+
+    @GetMapping("/profile")
+    public String profile(Authentication authentication, Model model) {
+        if (authentication == null) {
+            return "redirect:/login";
+        }
+        User user = (User) authentication.getPrincipal();
+        model.addAttribute("user", user);
+        model.addAttribute("pageTitle", "Profile");
+        return "profile";
+    }
+
+    @GetMapping("/rentals")
+    public String rentals(Authentication authentication, Model model) {
+        if (authentication == null) {
+            return "redirect:/login";
+        }
+        User user = (User) authentication.getPrincipal();
+        model.addAttribute("rentals", rentalService.getCurrentRentals(user));
+        model.addAttribute("pageTitle", "My Rentals");
+        return "rentals";
+    }
+
+    @GetMapping("/reservations")
+    public String reservations(Authentication authentication, Model model) {
+        if (authentication == null) {
+            return "redirect:/login";
+        }
+        User user = (User) authentication.getPrincipal();
+        model.addAttribute("reservations", reservationService.findByUser(user));
+        model.addAttribute("pageTitle", "My Reservations");
+        return "reservations";
+    }
+}

--- a/library-management/src/main/java/com/library/controller/RentalController.java
+++ b/library-management/src/main/java/com/library/controller/RentalController.java
@@ -1,0 +1,42 @@
+package com.library.controller;
+
+import com.library.entity.Book;
+import com.library.entity.User;
+import com.library.service.BookService;
+import com.library.service.RentalService;
+import com.library.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class RentalController {
+
+    @Autowired
+    private RentalService rentalService;
+
+    @Autowired
+    private BookService bookService;
+
+    @PostMapping("/rentals/rent")
+    public String rentBook(@RequestParam Long bookId,
+                           @RequestParam int weeks,
+                           Authentication authentication,
+                           RedirectAttributes redirectAttributes) {
+        if (authentication == null) {
+            return "redirect:/login";
+        }
+        User user = (User) authentication.getPrincipal();
+        Book book = bookService.getBook(bookId);
+        try {
+            rentalService.rentBook(user, book, weeks);
+            redirectAttributes.addFlashAttribute("successMessage", "Book rented successfully");
+        } catch (Exception ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        }
+        return "redirect:/books/" + bookId + "/details";
+    }
+}

--- a/library-management/src/main/java/com/library/entity/Book.java
+++ b/library-management/src/main/java/com/library/entity/Book.java
@@ -24,15 +24,19 @@ public class Book {
     private String description;
 
     @Column(nullable = false)
+    private int quantity = 1;
+
+    @Column(nullable = false)
     private boolean available = true;
 
     public Book() {}
 
-    public Book(String title, String author, String description, boolean available) {
+    public Book(String title, String author, String description, boolean available, int quantity) {
         this.title = title;
         this.author = author;
         this.description = description;
         this.available = available;
+        this.quantity = quantity;
     }
 
     public Long getId() { return id; }
@@ -46,6 +50,9 @@ public class Book {
 
     public String getDescription() { return description; }
     public void setDescription(String description) { this.description = description; }
+
+    public int getQuantity() { return quantity; }
+    public void setQuantity(int quantity) { this.quantity = quantity; }
 
     public boolean isAvailable() { return available; }
     public void setAvailable(boolean available) { this.available = available; }

--- a/library-management/src/main/java/com/library/service/BookService.java
+++ b/library-management/src/main/java/com/library/service/BookService.java
@@ -35,6 +35,11 @@ public class BookService {
     }
 
     public Book saveBook(Book book) {
+        if (book.getQuantity() <= 0) {
+            book.setAvailable(false);
+        } else {
+            book.setAvailable(true);
+        }
         return bookRepository.save(book);
     }
 

--- a/library-management/src/main/java/com/library/service/RentalService.java
+++ b/library-management/src/main/java/com/library/service/RentalService.java
@@ -1,7 +1,9 @@
 package com.library.service;
 
+import com.library.entity.Book;
 import com.library.entity.Rental;
 import com.library.entity.User;
+import com.library.repository.BookRepository;
 import com.library.repository.RentalRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,9 @@ public class RentalService {
     @Autowired
     private RentalRepository rentalRepository;
 
+    @Autowired
+    private BookRepository bookRepository;
+
     @Transactional(readOnly = true)
     public List<Rental> getCurrentRentals(User user) {
         return rentalRepository.findByUserAndReturnedDateIsNull(user);
@@ -29,5 +34,22 @@ public class RentalService {
     @Transactional(readOnly = true)
     public long countOverdueRentals(User user) {
         return rentalRepository.findOverdue(user, LocalDate.now()).size();
+    }
+
+    public Rental rentBook(User user, Book book, int weeks) {
+        if (book.getQuantity() <= 0) {
+            throw new RuntimeException("Book not available");
+        }
+
+        Rental rental = new Rental(user, book, LocalDate.now(), LocalDate.now().plusWeeks(weeks));
+        Rental saved = rentalRepository.save(rental);
+
+        book.setQuantity(book.getQuantity() - 1);
+        if (book.getQuantity() <= 0) {
+            book.setAvailable(false);
+        }
+        bookRepository.save(book);
+
+        return saved;
     }
 }

--- a/library-management/src/main/resources/schema.sql
+++ b/library-management/src/main/resources/schema.sql
@@ -24,6 +24,7 @@ CREATE TABLE IF NOT EXISTS books (
     title VARCHAR(255) NOT NULL,
     author VARCHAR(255) NOT NULL,
     description TEXT,
+    quantity INTEGER NOT NULL DEFAULT 1,
     available BOOLEAN NOT NULL DEFAULT TRUE
 );
 

--- a/library-management/src/main/resources/templates/admin/books/form.html
+++ b/library-management/src/main/resources/templates/admin/books/form.html
@@ -26,6 +26,10 @@
             <label for="description" class="form-label">Description</label>
             <textarea class="form-control" id="description" rows="3" th:field="*{description}"></textarea>
         </div>
+        <div class="mb-3">
+            <label for="quantity" class="form-label">Quantity</label>
+            <input type="number" class="form-control" id="quantity" th:field="*{quantity}" min="0">
+        </div>
         <div class="form-check mb-3">
             <input class="form-check-input" type="checkbox" id="available" th:field="*{available}">
             <label class="form-check-label" for="available">Available</label>

--- a/library-management/src/main/resources/templates/admin/books/list.html
+++ b/library-management/src/main/resources/templates/admin/books/list.html
@@ -22,6 +22,7 @@
                 <th>ID</th>
                 <th>Title</th>
                 <th>Author</th>
+                <th>Quantity</th>
                 <th>Available</th>
                 <th>Actions</th>
             </tr>
@@ -31,9 +32,8 @@
                 <td th:text="${book.id}"></td>
                 <td th:text="${book.title}"></td>
                 <td th:text="${book.author}"></td>
-                <td>
-                    <span th:text="${book.available} ? 'Yes' : 'No'"></span>
-                </td>
+                <td th:text="${book.quantity}"></td>
+                <td><span th:text="${book.available} ? 'Yes' : 'No'"></span></td>
                 <td>
                     <a th:href="@{'/admin/books/' + ${book.id} + '/edit'}" class="btn btn-sm btn-primary"><i class="bi bi-pencil"></i> Edit</a>
                     <form th:action="@{'/admin/books/' + ${book.id} + '/delete'}" method="post" class="d-inline">

--- a/library-management/src/main/resources/templates/books/details.html
+++ b/library-management/src/main/resources/templates/books/details.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -16,6 +16,23 @@
     <p>
         Status: <span th:text="${book.available} ? 'Available' : 'Unavailable'"></span>
     </p>
+    <p>Available copies: <span th:text="${book.quantity}"></span></p>
+
+    <div sec:authorize="isAuthenticated()">
+        <form th:action="@{/rentals/rent}" method="post" class="mt-3">
+            <input type="hidden" name="bookId" th:value="${book.id}" />
+            <div class="mb-3">
+                <label for="weeks" class="form-label">Rent for</label>
+                <select id="weeks" name="weeks" class="form-select">
+                    <option value="1">1 week</option>
+                    <option value="2">2 weeks</option>
+                    <option value="3">3 weeks</option>
+                    <option value="4">4 weeks</option>
+                </select>
+            </div>
+            <button type="submit" class="btn btn-primary" th:disabled="${book.quantity == 0}">Rent</button>
+        </form>
+    </div>
     <a th:href="@{/books}" class="btn btn-secondary">Back to list</a>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>

--- a/library-management/src/main/resources/templates/books/list.html
+++ b/library-management/src/main/resources/templates/books/list.html
@@ -73,6 +73,9 @@
                             <p class="card-text" th:text="${book.description}">Description</p>
                             <div class="d-flex justify-content-between align-items-center mb-3">
                                 <span class="badge" th:classappend="${book.available} ? 'bg-success' : 'bg-secondary'" th:text="${book.available} ? 'Available' : 'Unavailable'"></span>
+                                <span class="ms-2 text-muted small">(
+                                    <span th:text="${book.quantity}">0</span> left)
+                                </span>
                                 <a th:href="@{'/books/' + ${book.id} + '/details'}" class="btn btn-sm btn-outline-primary">
                                     <i class="bi bi-eye"></i> Details
                                 </a>

--- a/library-management/src/main/resources/templates/dashboard.html
+++ b/library-management/src/main/resources/templates/dashboard.html
@@ -122,13 +122,13 @@
                         <a th:href="@{/books}" class="btn btn-primary">
                             <i class="bi bi-search"></i> Browse Books
                         </a>
-                        <a href="#" class="btn btn-outline-primary">
+                        <a th:href="@{/profile}" class="btn btn-outline-primary">
                             <i class="bi bi-person-gear"></i> Update Profile
                         </a>
-                        <a href="#" class="btn btn-outline-info">
+                        <a th:href="@{/rentals}" class="btn btn-outline-info">
                             <i class="bi bi-clock-history"></i> View Rental History
                         </a>
-                        <a href="#" class="btn btn-outline-success">
+                        <a th:href="@{/reservations}" class="btn btn-outline-success">
                             <i class="bi bi-bookmark-plus"></i> Manage Reservations
                         </a>
                     </div>

--- a/library-management/src/main/resources/templates/profile.html
+++ b/library-management/src/main/resources/templates/profile.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Profile</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav th:replace="fragments/navbar :: navbar"></nav>
+<div class="container my-5">
+    <h1 class="h4 mb-4">Profile</h1>
+    <p><strong>Username:</strong> <span th:text="${user.username}">user</span></p>
+    <p><strong>Email:</strong> <span th:text="${user.email}">email</span></p>
+    <p><strong>Name:</strong> <span th:text="${user.firstName + ' ' + user.lastName}">name</span></p>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/rentals.html
+++ b/library-management/src/main/resources/templates/rentals.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">My Rentals</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav th:replace="fragments/navbar :: navbar"></nav>
+<div class="container my-5">
+    <h1 class="h4 mb-4">My Rentals</h1>
+    <div th:if="${#lists.isEmpty(rentals)}">
+        <p class="text-muted">No active rentals.</p>
+    </div>
+    <div th:unless="${#lists.isEmpty(rentals)}">
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>Book</th>
+                <th>Rented Date</th>
+                <th>Due Date</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="r : ${rentals}">
+                <td th:text="${r.book.title}">Title</td>
+                <td th:text="${#dates.format(r.rentedDate, 'yyyy-MM-dd')}">date</td>
+                <td th:text="${#dates.format(r.dueDate, 'yyyy-MM-dd')}">date</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/reservations.html
+++ b/library-management/src/main/resources/templates/reservations.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">My Reservations</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav th:replace="fragments/navbar :: navbar"></nav>
+<div class="container my-5">
+    <h1 class="h4 mb-4">My Reservations</h1>
+    <div th:if="${#lists.isEmpty(reservations)}">
+        <p class="text-muted">No reservations.</p>
+    </div>
+    <div th:unless="${#lists.isEmpty(reservations)}">
+        <table class="table table-striped">
+            <thead>
+            <tr>
+                <th>Book</th>
+                <th>Reservation Date</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="r : ${reservations}">
+                <td th:text="${r.book.title}">Title</td>
+                <td th:text="${#dates.format(r.reservationDate, 'yyyy-MM-dd')}">date</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- track book quantity and toggle availability based on it
- allow creating rentals with configurable duration
- display quantity in book list and details page
- add profile, rentals and reservations pages
- hook up dashboard quick actions
- extend database schema for book quantity

## Testing
- `bash mvnw -q test` *(fails: mvnw not functional)*

------
https://chatgpt.com/codex/tasks/task_e_685e00762d2c832fac5365889bf481b5