### PR TITLE
Ensure quantity column exists for books

### DIFF
--- a/library-management/src/main/resources/schema.sql
+++ b/library-management/src/main/resources/schema.sql
@@ -28,6 +28,9 @@ CREATE TABLE IF NOT EXISTS books (
     available BOOLEAN NOT NULL DEFAULT TRUE
 );
 
+-- Ensure quantity column exists for older installations
+ALTER TABLE books ADD COLUMN IF NOT EXISTS quantity INTEGER NOT NULL DEFAULT 1;
+
 CREATE TABLE IF NOT EXISTS rentals (
     id SERIAL PRIMARY KEY,
     user_id BIGINT NOT NULL REFERENCES users(id),


### PR DESCRIPTION
## Summary
- ensure that the `quantity` column exists by adding an `ALTER TABLE` statement in `schema.sql`

## Testing
- `mvn test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e034de0e0832fa1bf7127844a3cb6