### PR TITLE
Add rental admin panel and reservation notifications

### DIFF
--- a/library-management/src/main/java/com/library/controller/AdminRentalController.java
+++ b/library-management/src/main/java/com/library/controller/AdminRentalController.java
@@ -1,0 +1,31 @@
+package com.library.controller;
+
+import com.library.service.RentalService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/admin/rentals")
+public class AdminRentalController {
+
+    @Autowired
+    private RentalService rentalService;
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("rentals", rentalService.findAll());
+        model.addAttribute("pageTitle", "Manage Rentals");
+        return "admin/rentals/list";
+    }
+
+    @PostMapping("/{id}/return")
+    public String markReturned(@PathVariable Long id) {
+        rentalService.markReturned(id);
+        return "redirect:/admin/rentals";
+    }
+}

--- a/library-management/src/main/java/com/library/controller/NotificationAdvice.java
+++ b/library-management/src/main/java/com/library/controller/NotificationAdvice.java
@@ -1,0 +1,25 @@
+package com.library.controller;
+
+import com.library.entity.User;
+import com.library.service.NotificationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.ui.Model;
+
+@ControllerAdvice
+public class NotificationAdvice {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @ModelAttribute
+    public void addNotifications(Model model, Authentication authentication) {
+        if (authentication != null && authentication.isAuthenticated()) {
+            User user = (User) authentication.getPrincipal();
+            model.addAttribute("notifications", notificationService.getNotifications(user));
+            model.addAttribute("unreadCount", notificationService.countUnread(user));
+        }
+    }
+}

--- a/library-management/src/main/java/com/library/controller/NotificationController.java
+++ b/library-management/src/main/java/com/library/controller/NotificationController.java
@@ -1,0 +1,35 @@
+package com.library.controller;
+
+import com.library.entity.Notification;
+import com.library.entity.User;
+import com.library.service.NotificationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@Controller
+public class NotificationController {
+
+    @Autowired
+    private NotificationService notificationService;
+
+    @GetMapping("/notifications/{id}/open")
+    public String openNotification(@PathVariable Long id, Authentication authentication) {
+        String redirect = "/";
+        if (authentication != null) {
+            User user = (User) authentication.getPrincipal();
+            for (Notification n : notificationService.getNotifications(user)) {
+                if (n.getId().equals(id)) {
+                    notificationService.markAsRead(id);
+                    if (n.getLink() != null && !n.getLink().isBlank()) {
+                        redirect = n.getLink();
+                    }
+                    break;
+                }
+            }
+        }
+        return "redirect:" + redirect;
+    }
+}

--- a/library-management/src/main/java/com/library/controller/ReservationController.java
+++ b/library-management/src/main/java/com/library/controller/ReservationController.java
@@ -4,6 +4,7 @@ import com.library.entity.Book;
 import com.library.entity.User;
 import com.library.service.BookService;
 import com.library.service.ReservationService;
+import com.library.service.NotificationService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -20,6 +21,9 @@ public class ReservationController {
     @Autowired
     private BookService bookService;
 
+    @Autowired
+    private NotificationService notificationService;
+
     @PostMapping("/reservations/reserve")
     public String reserveBook(@RequestParam Long bookId,
                               Authentication authentication,
@@ -31,6 +35,9 @@ public class ReservationController {
         Book book = bookService.getBook(bookId);
         try {
             reservationService.reserveBook(user, book);
+            notificationService.createNotification(user,
+                    "Reserved book: " + book.getTitle(),
+                    "/reservations");
             redirectAttributes.addFlashAttribute("successMessage", "Book reserved successfully");
         } catch (Exception ex) {
             redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());

--- a/library-management/src/main/java/com/library/entity/Notification.java
+++ b/library-management/src/main/java/com/library/entity/Notification.java
@@ -1,0 +1,53 @@
+package com.library.entity;
+
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notifications")
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String message;
+
+    private String link;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean read = false;
+
+    @Column(name = "created_date", nullable = false)
+    private LocalDateTime createdDate = LocalDateTime.now();
+
+    public Notification() {}
+
+    public Notification(User user, String message, String link) {
+        this.user = user;
+        this.message = message;
+        this.link = link;
+    }
+
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public User getUser() { return user; }
+    public void setUser(User user) { this.user = user; }
+
+    public String getMessage() { return message; }
+    public void setMessage(String message) { this.message = message; }
+
+    public String getLink() { return link; }
+    public void setLink(String link) { this.link = link; }
+
+    public boolean isRead() { return read; }
+    public void setRead(boolean read) { this.read = read; }
+
+    public LocalDateTime getCreatedDate() { return createdDate; }
+    public void setCreatedDate(LocalDateTime createdDate) { this.createdDate = createdDate; }
+}

--- a/library-management/src/main/java/com/library/repository/NotificationRepository.java
+++ b/library-management/src/main/java/com/library/repository/NotificationRepository.java
@@ -1,0 +1,12 @@
+package com.library.repository;
+
+import com.library.entity.Notification;
+import com.library.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+    List<Notification> findByUserOrderByCreatedDateDesc(User user);
+    long countByUserAndReadFalse(User user);
+}

--- a/library-management/src/main/java/com/library/service/BookService.java
+++ b/library-management/src/main/java/com/library/service/BookService.java
@@ -35,11 +35,6 @@ public class BookService {
     }
 
     public Book saveBook(Book book) {
-        if (book.getQuantity() <= 0) {
-            book.setAvailable(false);
-        } else {
-            book.setAvailable(true);
-        }
         return bookRepository.save(book);
     }
 

--- a/library-management/src/main/java/com/library/service/NotificationService.java
+++ b/library-management/src/main/java/com/library/service/NotificationService.java
@@ -1,0 +1,42 @@
+package com.library.service;
+
+import com.library.entity.Notification;
+import com.library.entity.User;
+import com.library.repository.NotificationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class NotificationService {
+
+    @Autowired
+    private NotificationRepository notificationRepository;
+
+    public Notification createNotification(User user, String message, String link) {
+        Notification n = new Notification(user, message, link);
+        return notificationRepository.save(n);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Notification> getNotifications(User user) {
+        return notificationRepository.findByUserOrderByCreatedDateDesc(user);
+    }
+
+    @Transactional(readOnly = true)
+    public long countUnread(User user) {
+        return notificationRepository.countByUserAndReadFalse(user);
+    }
+
+    public void markAsRead(Long id) {
+        notificationRepository.findById(id).ifPresent(n -> {
+            if (!n.isRead()) {
+                n.setRead(true);
+                notificationRepository.save(n);
+            }
+        });
+    }
+}

--- a/library-management/src/main/java/com/library/service/RentalService.java
+++ b/library-management/src/main/java/com/library/service/RentalService.java
@@ -45,11 +45,25 @@ public class RentalService {
         Rental saved = rentalRepository.save(rental);
 
         book.setQuantity(book.getQuantity() - 1);
-        if (book.getQuantity() <= 0) {
-            book.setAvailable(false);
-        }
         bookRepository.save(book);
 
         return saved;
+    }
+
+    @Transactional(readOnly = true)
+    public List<Rental> findAll() {
+        return rentalRepository.findAll();
+    }
+
+    public void markReturned(Long rentalId) {
+        Rental rental = rentalRepository.findById(rentalId)
+                .orElseThrow(() -> new RuntimeException("Rental not found"));
+        if (rental.getReturnedDate() == null) {
+            rental.setReturnedDate(LocalDate.now());
+            rentalRepository.save(rental);
+            Book book = rental.getBook();
+            book.setQuantity(book.getQuantity() + 1);
+            bookRepository.save(book);
+        }
     }
 }

--- a/library-management/src/main/resources/schema.sql
+++ b/library-management/src/main/resources/schema.sql
@@ -63,3 +63,12 @@ CREATE TABLE IF NOT EXISTS viewed_books (
     viewed_date TIMESTAMP NOT NULL
 );
 
+CREATE TABLE IF NOT EXISTS notifications (
+    id SERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id),
+    message VARCHAR(255) NOT NULL,
+    link VARCHAR(255),
+    is_read BOOLEAN NOT NULL DEFAULT FALSE,
+    created_date TIMESTAMP NOT NULL
+);
+

--- a/library-management/src/main/resources/templates/admin/dashboard.html
+++ b/library-management/src/main/resources/templates/admin/dashboard.html
@@ -17,6 +17,9 @@
         <a th:href="@{/admin/books}" class="list-group-item list-group-item-action">
             <i class="bi bi-book"></i> Manage Books
         </a>
+        <a th:href="@{/admin/rentals}" class="list-group-item list-group-item-action">
+            <i class="bi bi-clock-history"></i> Manage Rentals
+        </a>
         <a th:href="@{/admin/users}" class="list-group-item list-group-item-action">
             <i class="bi bi-people"></i> Manage Users
         </a>

--- a/library-management/src/main/resources/templates/admin/rentals/list.html
+++ b/library-management/src/main/resources/templates/admin/rentals/list.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Manage Rentals</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav th:replace="fragments/navbar :: navbar"></nav>
+<div class="container my-5">
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Manage Rentals</h1>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>User</th>
+            <th>Book</th>
+            <th>Rented</th>
+            <th>Due</th>
+            <th>Status</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="r : ${rentals}">
+            <td th:text="${r.id}"></td>
+            <td th:text="${r.user.username}"></td>
+            <td th:text="${r.book.title}"></td>
+            <td th:text="${#temporals.format(r.rentedDate, 'yyyy-MM-dd')}"></td>
+            <td th:text="${#temporals.format(r.dueDate, 'yyyy-MM-dd')}"></td>
+            <td>
+                <span th:text="${r.returnedDate != null} ? 'Returned' : 'Rented'"></span>
+            </td>
+            <td>
+                <form th:if="${r.returnedDate == null}" th:action="@{'/admin/rentals/' + ${r.id} + '/return'}" method="post">
+                    <button type="submit" class="btn btn-sm btn-success"><i class="bi bi-arrow-return-left"></i> Return</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/fragments/navbar.html
+++ b/library-management/src/main/resources/templates/fragments/navbar.html
@@ -29,6 +29,22 @@
             </form>
             <ul class="navbar-nav">
                 <li class="nav-item dropdown" sec:authorize="isAuthenticated()">
+                    <a class="nav-link" href="#" role="button" data-bs-toggle="dropdown">
+                        <i class="bi bi-bell"></i>
+                        <span class="badge bg-danger" th:if="${unreadCount > 0}" th:text="${unreadCount}"></span>
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end">
+                        <li th:each="n : ${notifications}">
+                            <a class="dropdown-item" th:href="@{'/notifications/' + ${n.id} + '/open'}"
+                               th:classappend="${n.read} ? 'text-muted' : 'fw-bold'"
+                               th:text="${n.message}"></a>
+                        </li>
+                        <li th:if="${#lists.isEmpty(notifications)}">
+                            <span class="dropdown-item text-muted">No notifications</span>
+                        </li>
+                    </ul>
+                </li>
+                <li class="nav-item dropdown" sec:authorize="isAuthenticated()">
                     <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown">
                         <i class="bi bi-person-circle"></i> <span sec:authentication="name">User</span>
                     </a>


### PR DESCRIPTION
## Summary
- add Notification entity, repository, service, controller and advice
- show notifications in navbar via bell icon with unread count
- create AdminRentalController and listing template
- link Manage Rentals in admin dashboard
- store notifications on reservation
- allow manual book availability by removing auto-setting
- support marking rentals returned

## Testing
- `mvn test` *(fails: mvn wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e07af258c832f976f0e7bba987196