### PR TITLE
Add reservation management and book reviews

### DIFF
--- a/library-management/src/main/java/com/library/controller/AdminRentalController.java
+++ b/library-management/src/main/java/com/library/controller/AdminRentalController.java
@@ -1,6 +1,8 @@
 package com.library.controller;
 
 import com.library.service.RentalService;
+import com.library.service.BookService;
+import com.library.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -16,11 +18,33 @@ public class AdminRentalController {
     @Autowired
     private RentalService rentalService;
 
+    @Autowired
+    private BookService bookService;
+
+    @Autowired
+    private UserService userService;
+
     @GetMapping
     public String list(Model model) {
         model.addAttribute("rentals", rentalService.findAll());
         model.addAttribute("pageTitle", "Manage Rentals");
         return "admin/rentals/list";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        model.addAttribute("rental", rentalService.getRental(id));
+        model.addAttribute("books", bookService.getAllBooks());
+        model.addAttribute("users", userService.findAllUsers());
+        model.addAttribute("pageTitle", "Edit Rental");
+        return "admin/rentals/form";
+    }
+
+    @PostMapping("/{id}")
+    public String update(@PathVariable Long id, @ModelAttribute com.library.entity.Rental rental) {
+        rental.setId(id);
+        rentalService.saveRental(rental);
+        return "redirect:/admin/rentals";
     }
 
     @PostMapping("/{id}/return")

--- a/library-management/src/main/java/com/library/controller/AdminReservationController.java
+++ b/library-management/src/main/java/com/library/controller/AdminReservationController.java
@@ -1,0 +1,52 @@
+package com.library.controller;
+
+import com.library.entity.Reservation;
+import com.library.service.ReservationService;
+import com.library.service.BookService;
+import com.library.service.UserService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+@Controller
+@RequestMapping("/admin/reservations")
+public class AdminReservationController {
+    @Autowired
+    private ReservationService reservationService;
+
+    @Autowired
+    private BookService bookService;
+
+    @Autowired
+    private UserService userService;
+
+    @GetMapping
+    public String list(Model model) {
+        model.addAttribute("reservations", reservationService.findAll());
+        model.addAttribute("pageTitle", "Manage Reservations");
+        return "admin/reservations/list";
+    }
+
+    @GetMapping("/{id}/edit")
+    public String editForm(@PathVariable Long id, Model model) {
+        model.addAttribute("reservation", reservationService.getReservation(id));
+        model.addAttribute("books", bookService.getAllBooks());
+        model.addAttribute("users", userService.findAllUsers());
+        model.addAttribute("pageTitle", "Edit Reservation");
+        return "admin/reservations/form";
+    }
+
+    @PostMapping("/{id}")
+    public String update(@PathVariable Long id, @ModelAttribute Reservation reservation) {
+        reservation.setId(id);
+        reservationService.updateReservation(id, reservation);
+        return "redirect:/admin/reservations";
+    }
+
+    @PostMapping("/{id}/delete")
+    public String delete(@PathVariable Long id) {
+        reservationService.deleteReservation(id);
+        return "redirect:/admin/reservations";
+    }
+}

--- a/library-management/src/main/java/com/library/controller/HomeController.java
+++ b/library-management/src/main/java/com/library/controller/HomeController.java
@@ -60,6 +60,7 @@ public class HomeController {
         Book book = bookService.getBook(id);
         model.addAttribute("book", book);
         model.addAttribute("pageTitle", "Book Details");
+        model.addAttribute("reviews", reviewService.findByBook(book));
 
         if (authentication != null && authentication.isAuthenticated()) {
             String username = authentication.getName();

--- a/library-management/src/main/java/com/library/controller/NotificationAdvice.java
+++ b/library-management/src/main/java/com/library/controller/NotificationAdvice.java
@@ -18,7 +18,7 @@ public class NotificationAdvice {
     public void addNotifications(Model model, Authentication authentication) {
         if (authentication != null && authentication.isAuthenticated()) {
             User user = (User) authentication.getPrincipal();
-            model.addAttribute("notifications", notificationService.getNotifications(user));
+            model.addAttribute("notifications", notificationService.getUnreadNotifications(user));
             model.addAttribute("unreadCount", notificationService.countUnread(user));
         }
     }

--- a/library-management/src/main/java/com/library/controller/NotificationController.java
+++ b/library-management/src/main/java/com/library/controller/NotificationController.java
@@ -20,9 +20,10 @@ public class NotificationController {
         String redirect = "/";
         if (authentication != null) {
             User user = (User) authentication.getPrincipal();
-            for (Notification n : notificationService.getNotifications(user)) {
+            for (Notification n : notificationService.getUnreadNotifications(user)) {
                 if (n.getId().equals(id)) {
                     notificationService.markAsRead(id);
+                    notificationService.deleteNotification(id);
                     if (n.getLink() != null && !n.getLink().isBlank()) {
                         redirect = n.getLink();
                     }

--- a/library-management/src/main/java/com/library/controller/ReservationController.java
+++ b/library-management/src/main/java/com/library/controller/ReservationController.java
@@ -44,4 +44,21 @@ public class ReservationController {
         }
         return "redirect:/books/" + bookId + "/details";
     }
+
+    @PostMapping("/reservations/{id}/cancel")
+    public String cancelReservation(@PathVariable Long id,
+                                    Authentication authentication,
+                                    RedirectAttributes redirectAttributes) {
+        if (authentication == null) {
+            return "redirect:/login";
+        }
+        User user = (User) authentication.getPrincipal();
+        try {
+            reservationService.cancelReservation(id, user);
+            redirectAttributes.addFlashAttribute("successMessage", "Reservation cancelled");
+        } catch (Exception ex) {
+            redirectAttributes.addFlashAttribute("errorMessage", ex.getMessage());
+        }
+        return "redirect:/reservations";
+    }
 }

--- a/library-management/src/main/java/com/library/controller/ReviewController.java
+++ b/library-management/src/main/java/com/library/controller/ReviewController.java
@@ -1,0 +1,37 @@
+package com.library.controller;
+
+import com.library.entity.Book;
+import com.library.entity.User;
+import com.library.service.BookService;
+import com.library.service.ReviewService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+@Controller
+public class ReviewController {
+    @Autowired
+    private ReviewService reviewService;
+
+    @Autowired
+    private BookService bookService;
+
+    @PostMapping("/reviews/add")
+    public String addReview(@RequestParam Long bookId,
+                            @RequestParam int rating,
+                            @RequestParam String comment,
+                            Authentication authentication,
+                            RedirectAttributes redirectAttributes) {
+        if (authentication == null) {
+            return "redirect:/login";
+        }
+        User user = (User) authentication.getPrincipal();
+        Book book = bookService.getBook(bookId);
+        reviewService.addReview(user, book, rating, comment);
+        redirectAttributes.addFlashAttribute("successMessage", "Review added");
+        return "redirect:/books/" + bookId + "/details";
+    }
+}

--- a/library-management/src/main/java/com/library/repository/NotificationRepository.java
+++ b/library-management/src/main/java/com/library/repository/NotificationRepository.java
@@ -8,5 +8,6 @@ import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
     List<Notification> findByUserOrderByCreatedDateDesc(User user);
+    List<Notification> findByUserAndReadFalseOrderByCreatedDateDesc(User user);
     long countByUserAndReadFalse(User user);
 }

--- a/library-management/src/main/java/com/library/repository/ReservationRepository.java
+++ b/library-management/src/main/java/com/library/repository/ReservationRepository.java
@@ -10,5 +10,7 @@ import java.util.List;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
     List<Reservation> findByUser(User user);
 
+    List<Reservation> findByBookOrderByReservationDateAsc(Book book);
+
     boolean existsByUserAndBook(User user, Book book);
 }

--- a/library-management/src/main/java/com/library/repository/ReviewRepository.java
+++ b/library-management/src/main/java/com/library/repository/ReviewRepository.java
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     long countByUser(User user);
+    java.util.List<Review> findByBookOrderByCreatedDateDesc(com.library.entity.Book book);
 }

--- a/library-management/src/main/java/com/library/service/NotificationService.java
+++ b/library-management/src/main/java/com/library/service/NotificationService.java
@@ -27,6 +27,11 @@ public class NotificationService {
     }
 
     @Transactional(readOnly = true)
+    public List<Notification> getUnreadNotifications(User user) {
+        return notificationRepository.findByUserAndReadFalseOrderByCreatedDateDesc(user);
+    }
+
+    @Transactional(readOnly = true)
     public long countUnread(User user) {
         return notificationRepository.countByUserAndReadFalse(user);
     }
@@ -38,5 +43,9 @@ public class NotificationService {
                 notificationRepository.save(n);
             }
         });
+    }
+
+    public void deleteNotification(Long id) {
+        notificationRepository.deleteById(id);
     }
 }

--- a/library-management/src/main/java/com/library/service/RentalService.java
+++ b/library-management/src/main/java/com/library/service/RentalService.java
@@ -5,6 +5,9 @@ import com.library.entity.Rental;
 import com.library.entity.User;
 import com.library.repository.BookRepository;
 import com.library.repository.RentalRepository;
+import com.library.repository.ReservationRepository;
+import com.library.service.NotificationService;
+import com.library.entity.Reservation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,9 +24,24 @@ public class RentalService {
     @Autowired
     private BookRepository bookRepository;
 
+    @Autowired
+    private ReservationRepository reservationRepository;
+
+    @Autowired
+    private NotificationService notificationService;
+
     @Transactional(readOnly = true)
     public List<Rental> getCurrentRentals(User user) {
         return rentalRepository.findByUserAndReturnedDateIsNull(user);
+    }
+
+    @Transactional(readOnly = true)
+    public Rental getRental(Long id) {
+        return rentalRepository.findById(id).orElseThrow(() -> new RuntimeException("Rental not found"));
+    }
+
+    public Rental saveRental(Rental rental) {
+        return rentalRepository.save(rental);
     }
 
     @Transactional(readOnly = true)
@@ -37,7 +55,7 @@ public class RentalService {
     }
 
     public Rental rentBook(User user, Book book, int weeks) {
-        if (book.getQuantity() <= 0) {
+        if (!book.isAvailable() || book.getQuantity() <= 0) {
             throw new RuntimeException("Book not available");
         }
 
@@ -64,6 +82,18 @@ public class RentalService {
             Book book = rental.getBook();
             book.setQuantity(book.getQuantity() + 1);
             bookRepository.save(book);
+
+            List<Reservation> reservations = reservationRepository.findByBookOrderByReservationDateAsc(book);
+            if (!reservations.isEmpty() && book.isAvailable() && book.getQuantity() > 0) {
+                Reservation first = reservations.get(0);
+                Rental newRental = new Rental(first.getUser(), book, LocalDate.now(), LocalDate.now().plusWeeks(1));
+                rentalRepository.save(newRental);
+                book.setQuantity(book.getQuantity() - 1);
+                bookRepository.save(book);
+                reservationRepository.delete(first);
+                notificationService.createNotification(first.getUser(),
+                        "Reservation for " + book.getTitle() + " has been converted to rental", "/rentals");
+            }
         }
     }
 }

--- a/library-management/src/main/java/com/library/service/ReservationService.java
+++ b/library-management/src/main/java/com/library/service/ReservationService.java
@@ -33,4 +33,37 @@ public class ReservationService {
         Reservation reservation = new Reservation(user, book);
         return reservationRepository.save(reservation);
     }
+
+    @Transactional(readOnly = true)
+    public List<Reservation> findAll() {
+        return reservationRepository.findAll();
+    }
+
+    @Transactional(readOnly = true)
+    public Reservation getReservation(Long id) {
+        return reservationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Reservation not found"));
+    }
+
+    public Reservation updateReservation(Long id, Reservation updated) {
+        Reservation existing = reservationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Reservation not found"));
+        existing.setBook(updated.getBook());
+        existing.setUser(updated.getUser());
+        existing.setReservationDate(updated.getReservationDate());
+        return reservationRepository.save(existing);
+    }
+
+    public void deleteReservation(Long id) {
+        reservationRepository.deleteById(id);
+    }
+
+    public void cancelReservation(Long id, User user) {
+        Reservation reservation = reservationRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Reservation not found"));
+        if (!reservation.getUser().equals(user)) {
+            throw new RuntimeException("Unauthorized");
+        }
+        reservationRepository.delete(reservation);
+    }
 }

--- a/library-management/src/main/java/com/library/service/ReviewService.java
+++ b/library-management/src/main/java/com/library/service/ReviewService.java
@@ -1,6 +1,8 @@
 package com.library.service;
 
 import com.library.entity.User;
+import com.library.entity.Book;
+import com.library.entity.Review;
 import com.library.repository.ReviewRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,5 +17,15 @@ public class ReviewService {
     @Transactional(readOnly = true)
     public long countByUser(User user) {
         return reviewRepository.countByUser(user);
+    }
+
+    public Review addReview(User user, Book book, int rating, String comment) {
+        Review r = new Review(user, book, rating, comment);
+        return reviewRepository.save(r);
+    }
+
+    @Transactional(readOnly = true)
+    public java.util.List<Review> findByBook(Book book) {
+        return reviewRepository.findByBookOrderByCreatedDateDesc(book);
     }
 }

--- a/library-management/src/main/resources/static/js/app.js
+++ b/library-management/src/main/resources/static/js/app.js
@@ -1,1 +1,8 @@
-﻿// Placeholder for app.js
+document.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('.alert').forEach(el => {
+        setTimeout(() => {
+            el.classList.add('fade');
+            el.addEventListener('transitionend', () => el.remove());
+        }, 4000);
+    });
+});

--- a/library-management/src/main/resources/templates/admin/dashboard.html
+++ b/library-management/src/main/resources/templates/admin/dashboard.html
@@ -20,6 +20,9 @@
         <a th:href="@{/admin/rentals}" class="list-group-item list-group-item-action">
             <i class="bi bi-clock-history"></i> Manage Rentals
         </a>
+        <a th:href="@{/admin/reservations}" class="list-group-item list-group-item-action">
+            <i class="bi bi-bookmark-check"></i> Manage Reservations
+        </a>
         <a th:href="@{/admin/users}" class="list-group-item list-group-item-action">
             <i class="bi bi-people"></i> Manage Users
         </a>

--- a/library-management/src/main/resources/templates/admin/rentals/form.html
+++ b/library-management/src/main/resources/templates/admin/rentals/form.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Edit Rental</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav th:replace="fragments/navbar :: navbar"></nav>
+<div class="container my-5">
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Edit Rental</h1>
+    <form th:action="@{'/admin/rentals/' + ${rental.id}}" method="post">
+        <div class="mb-3">
+            <label class="form-label">User</label>
+            <select class="form-select" name="user.id">
+                <option th:each="u : ${users}" th:value="${u.id}" th:text="${u.username}" th:selected="${u.id == rental.user.id}"></option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Book</label>
+            <select class="form-select" name="book.id">
+                <option th:each="b : ${books}" th:value="${b.id}" th:text="${b.title}" th:selected="${b.id == rental.book.id}"></option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Rented Date</label>
+            <input type="date" class="form-control" name="rentedDate" th:value="${#temporals.format(rental.rentedDate,'yyyy-MM-dd')}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Due Date</label>
+            <input type="date" class="form-control" name="dueDate" th:value="${#temporals.format(rental.dueDate,'yyyy-MM-dd')}">
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Returned Date</label>
+            <input type="date" class="form-control" name="returnedDate" th:value="${rental.returnedDate != null} ? ${#temporals.format(rental.returnedDate,'yyyy-MM-dd')} : ''">
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/admin/reservations/form.html
+++ b/library-management/src/main/resources/templates/admin/reservations/form.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Edit Reservation</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav th:replace="fragments/navbar :: navbar"></nav>
+<div class="container my-5">
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Edit Reservation</h1>
+    <form th:action="@{'/admin/reservations/' + ${reservation.id}}" method="post">
+        <div class="mb-3">
+            <label class="form-label">User</label>
+            <select class="form-select" name="user.id">
+                <option th:each="u : ${users}" th:value="${u.id}" th:text="${u.username}" th:selected="${u.id == reservation.user.id}"></option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Book</label>
+            <select class="form-select" name="book.id">
+                <option th:each="b : ${books}" th:value="${b.id}" th:text="${b.title}" th:selected="${b.id == reservation.book.id}"></option>
+            </select>
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Date</label>
+            <input type="date" class="form-control" name="reservationDate" th:value="${#temporals.format(reservation.reservationDate,'yyyy-MM-dd')}">
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/admin/reservations/list.html
+++ b/library-management/src/main/resources/templates/admin/reservations/list.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title th:text="${pageTitle}">Manage Reservations</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/css/style.css}" rel="stylesheet">
+</head>
+<body>
+<nav th:replace="fragments/navbar :: navbar"></nav>
+<div class="container my-5">
+    <h1 class="h4 mb-4" th:text="${pageTitle}">Manage Reservations</h1>
+    <table class="table table-striped">
+        <thead>
+        <tr>
+            <th>ID</th>
+            <th>User</th>
+            <th>Book</th>
+            <th>Date</th>
+            <th>Actions</th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr th:each="r : ${reservations}">
+            <td th:text="${r.id}"></td>
+            <td th:text="${r.user.username}"></td>
+            <td th:text="${r.book.title}"></td>
+            <td th:text="${#temporals.format(r.reservationDate,'yyyy-MM-dd')}"></td>
+            <td>
+                <a th:href="@{'/admin/reservations/' + ${r.id} + '/edit'}" class="btn btn-sm btn-primary">Edit</a>
+                <form th:action="@{'/admin/reservations/' + ${r.id} + '/delete'}" method="post" class="d-inline">
+                    <button type="submit" class="btn btn-sm btn-danger" onclick="return confirm('Delete reservation?');">Delete</button>
+                </form>
+            </td>
+        </tr>
+        </tbody>
+    </table>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/library-management/src/main/resources/templates/books/details.html
+++ b/library-management/src/main/resources/templates/books/details.html
@@ -30,13 +30,34 @@
                     <option value="4">4 weeks</option>
                 </select>
             </div>
-            <button type="submit" class="btn btn-primary" th:disabled="${book.quantity == 0}">Rent</button>
+            <button type="submit" class="btn btn-primary" th:disabled="${!book.available || book.quantity == 0}">Rent</button>
         </form>
-
-        <form th:action="@{/reservations/reserve}" method="post" class="mt-3" th:if="${book.quantity == 0}">
+        <form th:action="@{/reservations/reserve}" method="post" class="mt-3" th:if="${!book.available}">
             <input type="hidden" name="bookId" th:value="${book.id}" />
             <button type="submit" class="btn btn-warning">Reserve</button>
         </form>
+        <form th:action="@{/reviews/add}" method="post" class="mt-3">
+            <input type="hidden" name="bookId" th:value="${book.id}" />
+            <div class="mb-2">
+                <label class="form-label">Rating</label>
+                <select name="rating" class="form-select">
+                    <option th:each="i : ${#numbers.sequence(1,5)}" th:value="${i}" th:text="${i}"></option>
+                </select>
+            </div>
+            <div class="mb-2">
+                <label class="form-label">Comment</label>
+                <textarea name="comment" class="form-control"></textarea>
+            </div>
+            <button type="submit" class="btn btn-success">Add Review</button>
+        </form>
+    </div>
+    <div class="mt-5">
+        <h4>Reviews</h4>
+        <div th:each="rev : ${reviews}" class="mb-3 border-bottom pb-2">
+            <strong th:text="rev.user.username"></strong>
+            <span class="ms-2" th:text="'Rating: ' + rev.rating"></span>
+            <p th:text="rev.comment"></p>
+        </div>
     </div>
     <a th:href="@{/books}" class="btn btn-secondary">Back to list</a>
 </div>

--- a/library-management/src/main/resources/templates/books/list.html
+++ b/library-management/src/main/resources/templates/books/list.html
@@ -63,6 +63,7 @@
                     <p class="text-muted">No books found.</p>
                 </div>
                 <div th:each="book : ${books}" class="col-md-6 col-lg-4 mb-4">
+                    <a th:href="@{'/books/' + ${book.id} + '/details'}" class="text-decoration-none text-dark">
                     <div class="card book-card h-100">
                         <div class="book-cover bg-light d-flex align-items-center justify-content-center">
                             <i class="bi bi-book display-4 text-muted"></i>
@@ -76,12 +77,11 @@
                                 <span class="ms-2 text-muted small">(
                                     <span th:text="${book.quantity}">0</span> left)
                                 </span>
-                                <a th:href="@{'/books/' + ${book.id} + '/details'}" class="btn btn-sm btn-outline-primary">
-                                    <i class="bi bi-eye"></i> Details
-                                </a>
+                                
                             </div>
                         </div>
                     </div>
+                    </a>
                 </div>
             </div>
 

--- a/library-management/src/main/resources/templates/dashboard.html
+++ b/library-management/src/main/resources/templates/dashboard.html
@@ -52,9 +52,11 @@
                     <h5 class="mb-0"><i class="bi bi-book"></i> Available Books</h5>
                 </div>
                 <div class="card-body">
-                    <ul class="list-group list-group-flush" th:if="${books}">
-                        <li class="list-group-item" th:each="b : ${books}">
+                    <ul class="list-group list-group-flush" th:if="${books}" style="max-height: 200px; overflow-y: auto;">
+                        <li class="list-group-item" th:each="b, iter : ${books}" th:if="${iter.index} &lt; 3">
                             <a th:href="@{'/books/' + ${b.id} + '/details'}" th:text="${b.title} + ' by ' + ${b.author}">Book</a>
+                        </li>
+                        <li class="list-group-item text-center text-muted" th:if="${books.size()} > 3">...
                         </li>
                     </ul>
                 </div>

--- a/library-management/src/main/resources/templates/fragments/navbar.html
+++ b/library-management/src/main/resources/templates/fragments/navbar.html
@@ -70,3 +70,4 @@
         </div>
     </div>
 </nav>
+<script th:src="@{/js/app.js}"></script>

--- a/library-management/src/main/resources/templates/reservations.html
+++ b/library-management/src/main/resources/templates/reservations.html
@@ -20,12 +20,18 @@
             <tr>
                 <th>Book</th>
                 <th>Reservation Date</th>
+                <th>Actions</th>
             </tr>
             </thead>
             <tbody>
             <tr th:each="r : ${reservations}">
                 <td th:text="${r.book.title}">Title</td>
                 <td th:text="${#temporals.format(r.reservationDate, 'yyyy-MM-dd')}">date</td>
+                <td>
+                    <form th:action="@{'/reservations/' + ${r.id} + '/cancel'}" method="post" class="d-inline">
+                        <button type="submit" class="btn btn-sm btn-danger">Cancel</button>
+                    </form>
+                </td>
             </tr>
             </tbody>
         </table>


### PR DESCRIPTION
## Summary
- automate notifications and handle them as read
- enable editing rentals and reservations in admin panel
- allow users to cancel own reservations
- introduce ability to add reviews for books
- show only first three available books on dashboard
- adjust templates to open book details on click and allow reservations on unavailable titles
- auto-hide alerts using small JS helper

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e0b570e38832fb54ce4406277ae46