### PR TITLE
Fix registration password confirmation name mismatch

### DIFF
--- a/library-management/src/main/resources/templates/auth/register.html
+++ b/library-management/src/main/resources/templates/auth/register.html
@@ -61,10 +61,10 @@
                                     </div>
                                 </div>
                                 <div class="col-md-6 mb-3">
-                                    <label for="confirmHaslo" class="form-label">Potwierdz haslo</label>
+                                    <label for="confirmPassword" class="form-label">Potwierdz haslo</label>
                                     <div class="input-group">
                                         <span class="input-group-text"><i class="bi bi-lock-fill"></i></span>
-                                        <input type="password" class="form-control" id="confirmHaslo" name="confirmHaslo" required minlength="6">
+                                        <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" required minlength="6">
                                     </div>
                                 </div>
                             </div>
@@ -104,11 +104,11 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
     // Haslo confirmation validation
-    document.getElementById('confirmHaslo').addEventListener('input', function() {
+    document.getElementById('confirmPassword').addEventListener('input', function() {
         const password = document.getElementById('password').value;
-        const confirmHaslo = this.value;
+        const confirmPassword = this.value;
 
-        if (password !== confirmHaslo) {
+        if (password !== confirmPassword) {
             this.setCustomValidity('Hasla nie sa takie same');
         } else {
             this.setCustomValidity('');


### PR DESCRIPTION
## Summary
- fix `confirmPassword` field mismatch in registration page

## Testing
- `./mvnw -q test` *(fails: maven wrapper missing)*

------
https://chatgpt.com/codex/tasks/task_e_685e160273e0832f976d929e19acb70e